### PR TITLE
Issue: shortening URL containing a query param with no value causes Exce...

### DIFF
--- a/lib/truncator/url_parser.rb
+++ b/lib/truncator/url_parser.rb
@@ -43,7 +43,7 @@ module Truncator
 
         uri.special_format
       rescue Exception
-        return uri.to_s.truncate(truncation_length)
+        return uri.to_s.sub(/\Ahttp:\/\//, '').truncate(truncation_length)
       end
 
       private

--- a/spec/url_parser_spec.rb
+++ b/spec/url_parser_spec.rb
@@ -163,5 +163,13 @@ describe Truncator::UrlParser do
         Truncator::UrlParser.shorten_url(dangerous_url, 30).should == 'http://www.first.army.mil/f...'
       end
     end
+
+    context 'when URL contains query param with no value' do
+      let(:missing_param_value) { 'https://npiregistry.cms.hhs.gov/NPPESRegistry/DisplayProviderDetails.do?searchNpi=1629006051&city=&firstName=&orgName=&searchType=ind&state=&npi=1629006051&orgDba=&lastName=&zip' }
+
+      it 'should just perform a basic truncation' do
+        Truncator::UrlParser.shorten_url(missing_param_value).should == 'https://npiregistry.cms.hhs.gov/NPPESRegistry/DisplayProviderDetails.do?searchNpi=1629006051...'
+      end
+    end
   end
 end

--- a/spec/url_parser_spec.rb
+++ b/spec/url_parser_spec.rb
@@ -159,8 +159,8 @@ describe Truncator::UrlParser do
     context 'when URL is invalid URL' do
       let(:dangerous_url) { "http://www.first.army.mil/family/contentdisplayFAFP.asp?ContentID=133&SiteID=\"><script>alert(String.fromCharCode(88,83,83))</script>" }
 
-      it 'should just perform a basic truncation' do
-        Truncator::UrlParser.shorten_url(dangerous_url, 30).should == 'http://www.first.army.mil/f...'
+      it 'should just perform a basic truncation after removing http://' do
+        Truncator::UrlParser.shorten_url(dangerous_url, 30).should == 'www.first.army.mil/family/c...'
       end
     end
 

--- a/spec/url_parser_spec.rb
+++ b/spec/url_parser_spec.rb
@@ -168,7 +168,7 @@ describe Truncator::UrlParser do
       let(:missing_param_value) { 'https://npiregistry.cms.hhs.gov/NPPESRegistry/DisplayProviderDetails.do?searchNpi=1629006051&city=&firstName=&orgName=&searchType=ind&state=&npi=1629006051&orgDba=&lastName=&zip' }
 
       it 'should just perform a basic truncation' do
-        Truncator::UrlParser.shorten_url(missing_param_value).should == 'https://npiregistry.cms.hhs.gov/NPPESRegistry/DisplayProviderDetails.do?searchNpi=1629006051...'
+        Truncator::UrlParser.shorten_url(missing_param_value).should == 'https://npiregistry.cms.hhs.gov/NPPESRe...'
       end
     end
   end


### PR DESCRIPTION
...ption

ArgumentError: invalid data of application/x-www-form-urlencoded (searchNpi=1629006051&city=&firstName=&orgName=&searchType=ind&state=&npi=1629006051&orgDba=&lastName=&zip)
./lib/truncator/extended_uri.rb:48:in `query_parameters'
./lib/truncator/url_parser.rb:20:in`shorten_url'
./spec/url_parser_spec.rb:171:in `block (4 levels) in <top (required)>'
